### PR TITLE
Added memberPropertiesToMixWithMessage at params of ConversationController

### DIFF
--- a/test/testConversationController/index.html
+++ b/test/testConversationController/index.html
@@ -52,6 +52,13 @@
 
 
 		<script id='message-template' type="text/template">
+			{{#img_perfil}}
+				<img src='{{img_perfil}}' style='width:30px' align='abssmiddle' />
+			{{/img_perfil}}
+			{{^img_perfil}}
+				<img src='http://takingo.com/images/users/user.gif' style='width:30px' align='absmiddle' />
+			{{/img_perfil}}
+
 			Alias: {{alias}} | Mensaje: {{mensaje}} | Id: {{id}} |
 			{{#waiting}}⌚{{/waiting}}
 			{{^waiting}} 
@@ -61,6 +68,13 @@
 		</script>
 
 		<script id='member-template' type="text/template">
+			{{#img_perfil}}
+				<img src='{{img_perfil}}' style='width:30px' align='abssmiddle' />
+			{{/img_perfil}}
+			{{^img_perfil}}
+				<img src='http://takingo.com/images/users/user.gif' style='width:30px' align='absmiddle' />
+			{{/img_perfil}}
+
 			Alias: {{alias}} | Status: {{status}} | Id: {{id}}
 		</script>
 		<script id='member-wrapper-template' type="text/template">

--- a/test/testConversationController/testConversationController.js
+++ b/test/testConversationController/testConversationController.js
@@ -156,6 +156,8 @@ window.members = [
 var params = {
 	idConversation: 10000, 
 
+	memberPropertiesToMixWithMessage: ["alias", "img_perfil"], 
+
 	onCreateConversation: function(){
 		//console.log('Conversacion creada (onCreateConversation)');
 	},
@@ -317,7 +319,7 @@ function listeners(){
 		var message = {
 			mensaje: textMessage, 
 			id: _.now(), 
-			idUser: 55, 
+			idUser: 28, 
 			fecha: _.now(), 
 			waiting: true,
 		}
@@ -387,8 +389,8 @@ function listeners(){
 			//console.log(data);
 		});
 
-		cc.getPreviousUnloadedMessages(5, function(data){
-			//console.log(data.messages);
+		cc.getPreviousUnloadedMessages(5, function(messages){
+			//console.log(messages);
 			//console.log('getting old messages');
 		});
 
@@ -396,14 +398,16 @@ function listeners(){
 		//console.log('getting message');
 		//console.log(cc.getCDS().getMessage(1455));
 
-
-	});
-
-	setTimeout(function(){
+		/*
 		cc.getConversation(function(conversation){
 			alert('imprimida de nuevo');
 		});
-	}, 10000);
+		*/
+
+
+	});
+
+
 }
 
 $(document).ready(listeners);


### PR DESCRIPTION
If memberPropertiesToMixWithMessage is set at params of ConversationController, messages will heredate these properties from the member who wrote it. Messages are just extended for be used by the rendering functions of the custom controllers and no affecting data saved by ConversationDataStore.
